### PR TITLE
Buscar y ordenar los objectos de Message del historial y enviarlos al frontend

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 var mongoose = require('mongoose');
+const bodyParser = require('body-parser');
 var Schema = mongoose.Schema;
 
 var messageSchema = new Schema({
@@ -13,19 +14,20 @@ var messageSchema = new Schema({
     faved_by: [String]
     }
   },
-  { collection: 'chatrecicla-react'})
+  {
+    collection: 'chatrecicla-react',
+    // timestamps: true   <-- esta es una forma más estandarizada de guardar marcas de tiempo
+  }
+)
 
 var Message = mongoose.model('Message', messageSchema);
 
 mongoose.connect("mongodb+srv://justo:fn231093@cluster0-syxf1.mongodb.net/test?retryWrites=true&w=majority", { autoIndex: false, useNewUrlParser: true, dbName: 'chatrecicla'});
 
-
-
 var express = require('express');
 var socket = require('socket.io');
 
 var app = express();
-
 
 server = app.listen(8080, function(){
     console.log('server is running on port 8080')
@@ -35,12 +37,20 @@ io = socket(server);
 
 io.on('connection', (socket) => {
     console.log(socket.id);
-
+    // Encontrar mensages de la historia y emit ellos al app
+    Message.find()
+    .sort({timestamp: 'ASC'})
+    .then(messages => {
+        io.emit('RECEIVE_MESSAGE', messages, 'history');
+    }).catch(err => {
+        console.log(err);
+    });
+    // Escuchar para nuevos mensajes 
     socket.on('SEND_MESSAGE', function(data){
         const msg = new Message(data);
         msg.save(function(err, msg){
           if (err) return console.error(err)
         });
-        io.emit('RECEIVE_MESSAGE', data);
+        io.emit('RECEIVE_MESSAGE', data, 'message');
     })
 });


### PR DESCRIPTION
Solo un cambio en `index.js` que carga el historial antes de escuchar nuevos mensajes. Antes de las personas usan la aplicación, probablemente necesitemos verificar que no se pierdan nuevos mensajes en el tiempo entre el inicio de la carga del historial y el montaje del escuchador...